### PR TITLE
Remove whitespace from vendorID

### DIFF
--- a/sources/JosefinSlab-ThinItalic.ufo/fontinfo.plist
+++ b/sources/JosefinSlab-ThinItalic.ufo/fontinfo.plist
@@ -90,7 +90,7 @@
       <integer>34</integer>
     </array>
     <key>openTypeOS2VendorID</key>
-    <string> GOOG</string>
+    <string>GOOG</string>
     <key>openTypeOS2WeightClass</key>
     <integer>250</integer>
     <key>openTypeOS2WidthClass</key>


### PR DESCRIPTION
This looks like an unintentional mistake.